### PR TITLE
Update Module.php

### DIFF
--- a/src/Module.php
+++ b/src/Module.php
@@ -2,25 +2,8 @@
 
 namespace Phpro\DoctrineHydrationModule;
 
-use Zend\ModuleManager\Feature\AutoloaderProviderInterface;
-use Zend\ModuleManager\Feature\ConfigProviderInterface;
-
-class Module implements AutoloaderProviderInterface, ConfigProviderInterface
+class Module
 {
-    /**
-     * @return array
-     */
-    public function getAutoloaderConfig()
-    {
-        return array(
-            'Zend\Loader\StandardAutoloader' => array(
-                'namespaces' => array(
-                    __NAMESPACE__ => __DIR__,
-                ),
-            ),
-        );
-    }
-
     /**
      * @return array|mixed|\Traversable
      */


### PR DESCRIPTION
Composer relies on PSR-4 for autoloading. So `Module::getAutoloaderConfig` is no longer called.
Also, to be compliant with [Zend Component Installer](https://github.com/zendframework/zend-component-installer), removed `ConfigProviderInterface`